### PR TITLE
Run Knex locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist
 .env
 config/local.js
 package-lock.json
+.DS_Store
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 dist
 .env
 config/local.js
+package-lock.json
 tmp/

--- a/README.md
+++ b/README.md
@@ -31,3 +31,39 @@
 * User defined list columns in addition to the default firstName and lastName
 * Public endpoint to add a subscriber to a list, e.g. for an API integration/signup form
 * Request payload validation, maybe with something like this https://github.com/ctavan/express-validator
+
+
+## Knex seeds and migrations
+### Seeds
+#### Create
+```
+npm run seed the_name_of_seed
+
+# By default this runs on development, but can be overwritten:
+npm run seed the_name_of_seed NODE_ENV=development
+
+# Alternatively, for test seeds (the most common):
+npm run seed:test the_name_of_seed
+```
+
+#### Run
+```
+# Environment rules apply as above:
+npm run seed:run
+```
+
+### Migrations
+#### Create
+```
+npm run migrate the_name_of_migration
+```
+
+#### Run
+```
+npm run migrate:latest
+```
+
+#### Rollback
+```
+npm run migrate:rollback
+```

--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@
 * Have Redis running locally `brew install redis` and `brew services start redis`
 * Node.js 8.6.0 or later
 * npm or yarn
-* Knex CLI installed `npm install -g knex`
 
 ### Get the project running
 
 1. Replace `.env.example` with `.env` with your db config settings
 2. Replace `src/config/local.js` with your database settings (don't commit your changes to this file)
 3. Run `yarn` or `npm install`
-4. cd to the `src` directory and run `knex migrate:latest` to set up the database schema
+4. Run `npm run migrate:latest` to set up the database schema
 5. Run `yarn dev` to start the dev server
 
 ## TODO

--- a/package.json
+++ b/package.json
@@ -8,7 +8,14 @@
     "start": "NODE_ENV=production node dist/index.js",
     "dev": "NODE_ENV=development nodemon src/index.js --exec \"node -r dotenv/config -r babel-register\"",
     "clean": "rimraf dist",
-    "build": "npm run clean && mkdir -p dist && babel src -s -D -d dist"
+    "build": "npm run clean && mkdir -p dist && babel src -s -D -d dist",
+    "seed": "knex seed:make --knexfile ./src/knexfile.js --",
+    "seed:test": "NODE_ENV=test knex seed:make --knexfile ./src/knexfile.js --",
+    "seed:test:run": "NODE_ENV=test knex seed:run --knexfile ./src/knexfile.js",
+    "seed:run": "knex seed:run --knexfile ./src/knexfile.js",
+    "migrate": "knex migrate:make --knexfile ./src/knexfile.js --",
+    "migrate:latest": "knex migrate:latest --knexfile ./src/knexfile.js",
+    "migrate:rollback": "knex migrate:rollback --knexfile ./src/knexfile.js"
   },
   "keywords": [],
   "author": "",

--- a/src/config/local.js
+++ b/src/config/local.js
@@ -1,6 +1,0 @@
-module.exports = {
-  DB_HOST: 'localhost',
-  DB_USER: 'root',
-  DB_PASSWORD: '',
-  DB_NAME: 'openmail',
-};

--- a/src/knexfile.js
+++ b/src/knexfile.js
@@ -1,13 +1,14 @@
-const config = require('./config/local');
+const dotenv = require('dotenv');
+dotenv.config({ path: `${__dirname}/../.env` });
 
 module.exports = {
   development: {
     client: 'mysql',
     connection: {
-      host: config.DB_HOST,
-      user: config.DB_USER,
-      password: config.DB_PASSWORD,
-      database: config.DB_NAME,
+      host: process.env.DB_HOST,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME,
     },
     pool: {
       min: 2,
@@ -21,10 +22,10 @@ module.exports = {
   production: {
     client: 'mysql',
     connection: {
-      host: config.DB_HOST,
-      user: config.DB_USER,
-      password: config.DB_PASSWORD,
-      database: config.DB_NAME,
+      host: process.env.DB_HOST,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME,
     },
     pool: {
       min: 2,

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -1,15 +1,3 @@
-import knex from 'knex';
-
-const { DB_HOST, DB_USER, DB_PASSWORD, DB_NAME } = process.env;
-
-const db = knex({
-  client: 'mysql',
-  connection: {
-    host: DB_HOST,
-    user: DB_USER,
-    password: DB_PASSWORD,
-    database: DB_NAME,
-  },
-});
-
-export default db;
+var environment = process.env.NODE_ENV || 'development';
+var config = require('../knexfile.js')[environment];
+module.exports = require('knex')(config);


### PR DESCRIPTION
Remove the global dependency for Knex by running local NPM scripts. The removes means no more cd'ing into the src directory or having two DB config files. The new commands are:

## Seeds
### Create the seed
```
npm run seed the_name_of_seed
```
By default this runs on development, but can be overwritten:
```
npm run seed the_name_of_seed NODE_ENV=development
```

Alternatively, for test seeds (the most common):
```
npm run seed:test the_name_of_seed
```

### Run the seeds
Environment rules apply as above:
```
npm run seed:run
```

## Migrations
### Create a migration
```
npm run migrate the_name_of_migration
```

### Run the latest migration
```
npm run migrate:latest
```

### Rollback
```
npm run migrate:rollback
```